### PR TITLE
fix: 修复 request_id 超过 int 的 json 解析错误

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -1,28 +1,28 @@
 package conf
 
 type PcsResponseBase struct {
-	ErrorCode int  	 `json:"error_code"`
-	ErrorMsg  string `json:"error_msg"`
-	RequestID int `json:"request_id"`
+	ErrorCode int     `json:"error_code"`
+	ErrorMsg  string  `json:"error_msg"`
+	RequestID float64 `json:"request_id"`
 }
 
 type CloudDiskResponseBase struct {
-	ErrorCode int  	 `json:"errno"`
-	ErrorMsg  string `json:"errmsg"`
-	RequestID int `json:"request_id"`
+	ErrorCode int     `json:"errno"`
+	ErrorMsg  string  `json:"errmsg"`
+	RequestID float64 `json:"request_id"`
 }
 
 type TestDataConfig struct {
-	ClientID string
-	ClientSecret string
-	RedirectUri string
-	Code string
-	AccessToken string
-	RefreshToken string
-	Dir string
-	FsID uint64
-	Path string
-	LocalFilePath string
+	ClientID        string
+	ClientSecret    string
+	RedirectUri     string
+	Code            string
+	AccessToken     string
+	RefreshToken    string
+	Dir             string
+	FsID            uint64
+	Path            string
+	LocalFilePath   string
 	TranscodingType string
 }
 
@@ -30,8 +30,8 @@ const Version = "0.0.5"
 
 const (
 	BaiduOpenApiDomain = "https://openapi.baidu.com"
-	OpenApiDomain = "https://pan.baidu.com"
-	PcsDataDomain = "https://d.pcs.baidu.com"
+	OpenApiDomain      = "https://pan.baidu.com"
+	PcsDataDomain      = "https://d.pcs.baidu.com"
 )
 
 // 测试参数


### PR DESCRIPTION
# 问题描述
百度接口返回 request_id 很大，会出现超过 int 的情况，请求上传分片的时候出现；

接口返回数据如下：
```json
{
    "return_type": 2,
    "errno": 0,
    "info": {
        "size": 7547995,
        "category": 4,
        "fs_id": 785594356004402,
        "request_id": 421551960496220000,
        "path": "/apps/LinkinStar/go.png",
        "isdir": 0,
        "mtime": 1619590738,
        "ctime": 1619590738,
        "md5": "e87cf9899p9898c6b279d5556b808cc6"
    },
    "request_id": 421551960496221378
}
```

# 复现方式
无法每次准确复现，使用不同大小的文件进行上传，偶尔就能出现解析异常

# 解决方式
使用 float64 代替 int 解决，因为使用 uint64 还是会出现问题
